### PR TITLE
use non-deprecated Neovim diagnostic API

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -12,7 +12,7 @@ function! lightline#lsp#hints() abort
   if !lightline#lsp#linted()
     return ''
   endif
-  let l:counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Hint]])')
+  let l:counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "HINT" })')
   return l:counts == 0 ? '' : printf(s:indicator_hints . '%d', counts)
 endfunction
 
@@ -20,7 +20,7 @@ function! lightline#lsp#infos() abort
   if !lightline#lsp#linted()
     return ''
   endif
-  let l:counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Information]])')
+  let l:counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "INFO" })')
   return l:counts == 0 ? '' : printf(s:indicator_infos . '%d', counts)
 endfunction
 
@@ -28,7 +28,7 @@ function! lightline#lsp#warnings() abort
   if !lightline#lsp#linted()
     return ''
   endif
-  let l:counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Warning]])')
+  let l:counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "WARN" })')
   return l:counts == 0 ? '' : printf(s:indicator_warnings . '%d', counts)
 endfunction
 
@@ -36,7 +36,7 @@ function! lightline#lsp#errors() abort
   if !lightline#lsp#linted()
     return ''
   endif
-  let l:counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Error]])')
+  let l:counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "ERROR" })')
   return l:counts == 0 ? '' : printf(s:indicator_errors . '%d', counts)
 endfunction
 
@@ -44,10 +44,10 @@ function! lightline#lsp#ok() abort
   if !lightline#lsp#linted()
     return ''
   endif
-  let l:hint_counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Hint]])')
-  let l:info_counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Information]])')
-  let l:warn_counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Warning]])')
-  let l:error_counts = luaeval('vim.lsp.diagnostic.get_count('.bufnr().', [[Error]])')
+  let l:hint_counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "HINT" })')
+  let l:info_counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "INFO" })')
+  let l:warn_counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "WARN" })')
+  let l:error_counts = luaeval('#vim.diagnostic.get('.bufnr().', { severity = "ERROR" })')
   let l:counts = l:hint_counts+l:info_counts+l:warn_counts+l:error_counts
   return l:counts == 0 ? s:indicator_ok : ''
 endfunction


### PR DESCRIPTION
The `vim.lsp.diagnostic.get_count` API has been deprecated, and suggests using `vim.diagnostic.get` instead. This deprecation causes a LOT of warnings when opening any new buffer.

This change migrates to the new API. It seems to work correctly on my machine, but I'd definitely recommend trying it out yourself to make sure!