### PR TITLE
feat: Add update_in_insert option to diagnostics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The indicator to use when there are no diagnostic. Default is `OK`.
 
 ##### `g:lightline#lsp#update_in_insert`
 
-Update diagnostic in insert mode. Default is `v:false`.
+Update diagnostic in insert mode. Default is `v:true`.
 
 ### Using icons as indicators
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ The indicator to use when there are errors. Default is `E:`.
 
 The indicator to use when there are no diagnostic. Default is `OK`.
 
+##### `g:lightline#lsp#update_in_insert`
+
+Update diagnostic in insert mode. Default is `v:false`.
+
 ### Using icons as indicators
 
 If you would like to replace the default indicators with symbols like on the screenshot, then you'll need to ensure you have some "iconic fonts" installed, such as [Font Awesome](https://fontawesome.com). A common alternative is to replace your primary font with one of the [Patched Nerd Fonts](https://github.com/ryanoasis/nerd-fonts), which saves you from having to install multiple fonts.

--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -3,7 +3,7 @@ let s:indicator_infos = get(g:, 'lightline#lsp#indicator_infos', 'I: ')
 let s:indicator_warnings = get(g:, 'lightline#lsp#indicator_warnings', 'W: ')
 let s:indicator_errors = get(g:, 'lightline#lsp#indicator_errors', 'E: ')
 let s:indicator_ok = get(g:, 'lightline#lsp#indicator_ok', 'OK')
-let s:update_in_insert = get(g:, 'lightline#lsp#update_in_insert', v:false)
+let s:update_in_insert = get(g:, 'lightline#lsp#update_in_insert', v:true)
 
 if !exists('s:hint')
   let s:hint = ''
@@ -25,7 +25,7 @@ endif
 " Lightline components
 
 function! s:skip_update_in_insert() abort
-  return s:update_in_insert && mode() == 'i'
+  return !s:update_in_insert && mode() == 'i'
 endfunction
 
 function! lightline#lsp#hints() abort

--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -3,53 +3,94 @@ let s:indicator_infos = get(g:, 'lightline#lsp#indicator_infos', 'I: ')
 let s:indicator_warnings = get(g:, 'lightline#lsp#indicator_warnings', 'W: ')
 let s:indicator_errors = get(g:, 'lightline#lsp#indicator_errors', 'E: ')
 let s:indicator_ok = get(g:, 'lightline#lsp#indicator_ok', 'OK')
+let s:update_in_insert = get(g:, 'lightline#lsp#update_in_insert', v:false)
 
+if !exists('s:hint')
+  let s:hint = ''
+endif
+if !exists('s:info')
+  let s:info = ''
+endif
+if !exists('s:warn')
+  let s:warn = ''
+endif
+if !exists('s:error')
+  let s:error = ''
+endif
+if !exists('s:ok')
+  let s:ok = ''
+endif
 
 """"""""""""""""""""""
 " Lightline components
+
+function! s:skip_update_in_insert() abort
+  return s:update_in_insert && mode() == 'i'
+endfunction
 
 function! lightline#lsp#hints() abort
   if !lightline#lsp#linted()
     return ''
   endif
+  if s:skip_update_in_insert()
+    return s:hint
+  endif
   let l:counts = luaeval("require('lightline-lsp')._get_diagnostic_count('hint')")
-  return l:counts == 0 ? '' : printf(s:indicator_hints . '%d', counts)
+  let s:hint = l:counts == 0 ? '' : printf(s:indicator_hints . '%d', counts)
+  return s:hint
 endfunction
 
 function! lightline#lsp#infos() abort
   if !lightline#lsp#linted()
     return ''
   endif
+  if s:skip_update_in_insert()
+    return s:info
+  endif
   let l:counts = luaeval("require('lightline-lsp')._get_diagnostic_count('info')")
-  return l:counts == 0 ? '' : printf(s:indicator_infos . '%d', counts)
+  let s:info = l:counts == 0 ? '' : printf(s:indicator_infos . '%d', counts)
+  return s:info
 endfunction
 
 function! lightline#lsp#warnings() abort
   if !lightline#lsp#linted()
     return ''
   endif
+  if s:skip_update_in_insert()
+    return s:warn
+  endif
   let l:counts = luaeval("require('lightline-lsp')._get_diagnostic_count('warn')")
-  return l:counts == 0 ? '' : printf(s:indicator_warnings . '%d', counts)
+  let s:warn = l:counts == 0 ? '' : printf(s:indicator_warnings . '%d', counts)
+  return s:warn
 endfunction
 
 function! lightline#lsp#errors() abort
   if !lightline#lsp#linted()
     return ''
   endif
+  if s:skip_update_in_insert()
+    return s:error
+  endif
   let l:counts = luaeval("require('lightline-lsp')._get_diagnostic_count('error')")
-  return l:counts == 0 ? '' : printf(s:indicator_errors . '%d', counts)
+  let s:error = l:counts == 0 ? '' : printf(s:indicator_errors . '%d', counts)
+  return s:error
 endfunction
 
 function! lightline#lsp#ok() abort
   if !lightline#lsp#linted()
     return ''
   endif
+  if s:skip_update_in_insert()
+    return s:ok
+  endif
+  echom s:ok
   let l:hint_counts = luaeval("require('lightline-lsp')._get_diagnostic_count('hint')")
   let l:info_counts = luaeval("require('lightline-lsp')._get_diagnostic_count('info')")
   let l:warn_counts = luaeval("require('lightline-lsp')._get_diagnostic_count('warn')")
   let l:error_counts = luaeval("require('lightline-lsp')._get_diagnostic_count('error')")
   let l:counts = l:hint_counts+l:info_counts+l:warn_counts+l:error_counts
-  return l:counts == 0 ? s:indicator_ok : ''
+  let s:ok = l:counts == 0 ? s:indicator_ok : ''
+  return s:ok
 endfunction
 
 """"""""""""""""""


### PR DESCRIPTION
This PR adds the update_in_insert option, which allows users to control whether the LSP status indicators update while in insert mode.
simply set the `g:lightline#lsp#update_in_insert` variable to `v:false` to disable updates in insert mode, or `v:true` to enable them.