### PR TITLE
chore: buf_get_clients and get_active_clients deprecation warnings

### DIFF
--- a/autoload/lightline/lsp.vim
+++ b/autoload/lightline/lsp.vim
@@ -97,5 +97,5 @@ endfunction
 " Helper functions
 
 function! lightline#lsp#linted() abort
-  return !!luaeval('not vim.tbl_isempty(vim.lsp.buf_get_clients('.bufnr().'))')
+  return !!luaeval('not vim.tbl_isempty(vim.lsp.get_clients({buffer='.bufnr().'}))')
 endfunction

--- a/lua/lightline-lsp.lua
+++ b/lua/lightline-lsp.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local function is_lsp_attached()
-  return next(vim.lsp.buf_get_clients(0))
+  return next(vim.lsp.get_clients({buffer=0}))
 end
 
 local function get_count(buffer_number, diagnostic_type)
@@ -38,7 +38,7 @@ M._get_diagnostic_count = function (diagnostic_type)
     return 0
   end
 
-  local active_clients = vim.lsp.get_active_clients()
+  local active_clients = vim.lsp.get_clients()
   if vim.tbl_isempty(active_clients) then
     return 0
   end


### PR DESCRIPTION
Fix deprecation warnings for these 2 `vim.lsp` functions

https://neovim.io/doc/user/deprecated/#vim.lsp.buf_get_clients()
and
https://neovim.io/doc/user/deprecated/#vim.lsp.get_active_clients()

Doesn't throw error and continues working for me